### PR TITLE
Fix Draw3D problems

### DIFF
--- a/common/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/render/Draw3D.java
+++ b/common/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/render/Draw3D.java
@@ -562,7 +562,7 @@ public class Draw3D {
         RenderSystem.enableBlend();
         RenderSystem.defaultBlendFunc();
         RenderSystem.disableTexture();
-        RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
+        RenderSystem.setShader(GameRenderer::getPositionColorProgram);
 
 
         Vec3d camPos = mc.gameRenderer.getCamera().getPos();


### PR DESCRIPTION
An issue occurred during the update from version 1.19.2 to 1.19.3. The update caused boxes and lines to stop rendering due to a typo. This issue has now been resolved with the fix for issue #81. Since I was unable to get JOML working properly, as it uses different methods to obtain the Euler values, I decided to revert to the older code used in version 1.19.2 and earlier.