### PR TITLE
Fix: Rounding on `getBlock` on negative coords

### DIFF
--- a/src/main/java/xyz/wagyourtail/jsmacros/client/api/library/impl/FWorld.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/api/library/impl/FWorld.java
@@ -153,7 +153,7 @@ public class FWorld extends BaseLibrary {
     }
 
     public BlockDataHelper getBlock(Pos3D pos) {
-        return getBlock((int) pos.x, (int) pos.y, (int) pos.z);
+        return getBlock(Math.floor(pos.x), Math.floor(pos.y), Math.floor(pos.z));
     }
 
     public BlockDataHelper getBlock(BlockPosHelper pos) {


### PR DESCRIPTION
If the getBlock method was being accessed with the Pos3D class it was using different coordinates than the method with the BlockPosHelper as they both rounded differently. The Pos3D truncated just the different values while the BlockPosHelper floored the different values (which is the normal Minecraft way).

This means that the Pos3D way was incorrect which is now fixed.