### PR TITLE
Hashes in Base64

### DIFF
--- a/src/main/java/xyz/wagyourtail/jsmacros/client/api/library/impl/FUtils.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/api/library/impl/FUtils.java
@@ -125,11 +125,11 @@ public class FUtils extends BaseLibrary {
     }
 
     /**
-     * Hashes the given string with sha-256 the selected algorithm.
+     * Hashes the given string with the selected algorithm.
      *
-     * @param message   the message to hash
+     * @param message the message to hash
      * @param algorithm sha1 | sha256 | sha384 | sha512 | md2 | md5
-     * @return the hashed message.
+     * @return the hashed message (Hex)
      * @since 1.8.4
      */
     @Nullable
@@ -146,6 +146,47 @@ public class FUtils extends BaseLibrary {
             case "md2":
                 return DigestUtils.md2Hex(message);
             case "md5":
+                return DigestUtils.md5Hex(message);
+            default:
+                return message;
+        }
+    }
+
+    /**
+     * Hashes the given string with the selected algorithm.
+     *
+     * @param message the message to hash
+     * @param algorithm sha1 | sha256 | sha384 | sha512 | md2 | md5
+     * @param base64 encode the result in base64
+     * @return the hashed message (Hex or Base64)
+     * @since 1.9.1
+     */
+    @Nullable
+    public String hashString(@Nullable String message, String algorithm, Boolean base64) {
+        switch (algorithm) {
+            case "sha256":
+                if (base64)
+                    return new String(Base64.encodeBase64(DigestUtils.sha256(message)));
+                return DigestUtils.sha256Hex(message);
+            case "sha512":
+                if (base64)
+                    return new String(Base64.encodeBase64(DigestUtils.sha512(message)));
+                return DigestUtils.sha512Hex(message);
+            case "sha1":
+                if (base64)
+                    return new String(Base64.encodeBase64(DigestUtils.sha1(message)));
+                return DigestUtils.sha1Hex(message);
+            case "sha384":
+                if (base64)
+                    return new String(Base64.encodeBase64(DigestUtils.sha384(message)));
+                return DigestUtils.sha384Hex(message);
+            case "md2":
+                if (base64)
+                    return new String(Base64.encodeBase64(DigestUtils.md2(message)));
+                return DigestUtils.md2Hex(message);
+            case "md5":
+                if (base64)
+                    return new String(Base64.encodeBase64(DigestUtils.md5(message)));
                 return DigestUtils.md5Hex(message);
             default:
                 return message;


### PR DESCRIPTION
While working with WebSockets I had to generate a **Sec-WebSocket-Accept** header field in response to the **Sec-WebSocket-Key** header field, and I needed the Base64 encoded SHA-1 hash ([according RFC6455](https://datatracker.ietf.org/doc/html/rfc6455#section-1.3)), but The current JSMacros implementation returns a Hexadecimal string instead of a Byte Array.
So I added an overload with a base64 boolean parameter.
It is already tested and works as expected.
Example:
`Chat.log(Utils.hashString('RYVz6RwrQ89GCAbAoJLILg==258EAFA5-E914-47DA-95CA-C5AB0DC85B11', 'sha1', true));`
Correctly returns:
`PWc+xeCzMCEtmg87Zk7C/9plYPo=`
