### PR TITLE
Add EventService#unregisterOnStop for convenience

### DIFF
--- a/src/core/java/xyz/wagyourtail/jsmacros/core/classes/Registrable.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/classes/Registrable.java
@@ -1,0 +1,15 @@
+package xyz.wagyourtail.jsmacros.core.classes;
+
+/**
+ * @param <R> the return value of the methods. it's usually the self.
+ * @author aMelonRind
+ * @since 1.9.1
+ */
+public interface Registrable<R> {
+
+    R register();
+
+    // throws exception because of CommandBuilder
+    R unregister() throws Exception;
+
+}

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/language/BaseLanguage.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/language/BaseLanguage.java
@@ -88,7 +88,7 @@ public abstract class BaseLanguage<U, T extends BaseScriptContext<U>> {
                 }
 
                 ctx.getCtx().clearSyncObject();
-                if (!ctx.getCtx().hasMethodWrapperBeenInvoked) {
+                if (!ctx.getCtx().shouldKeepAlive()) {
                     ctx.getCtx().closeContext();
                 }
             }
@@ -134,7 +134,7 @@ public abstract class BaseLanguage<U, T extends BaseScriptContext<U>> {
                 }
 
                 ctx.getCtx().clearSyncObject();
-                if (!ctx.getCtx().hasMethodWrapperBeenInvoked) {
+                if (!ctx.getCtx().shouldKeepAlive()) {
                     ctx.getCtx().closeContext();
                 }
             }

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/language/BaseScriptContext.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/language/BaseScriptContext.java
@@ -1,17 +1,18 @@
 package xyz.wagyourtail.jsmacros.core.language;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.jetbrains.annotations.Nullable;
 import xyz.wagyourtail.jsmacros.core.Core;
 import xyz.wagyourtail.jsmacros.core.event.BaseEvent;
+import xyz.wagyourtail.jsmacros.core.event.IEventListener;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -37,6 +38,9 @@ public abstract class BaseScriptContext<T> {
     protected final Set<Thread> threads = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     protected final Map<Thread, EventContainer<? extends BaseScriptContext<T>>> events = new ConcurrentHashMap<>();
+
+    // <listener, event>
+    public final WeakHashMap<IEventListener, String> eventListeners = new WeakHashMap<>();
 
     public boolean hasMethodWrapperBeenInvoked = false;
 

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/language/BaseScriptContext.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/language/BaseScriptContext.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 import xyz.wagyourtail.jsmacros.core.Core;
 import xyz.wagyourtail.jsmacros.core.event.BaseEvent;
 import xyz.wagyourtail.jsmacros.core.event.IEventListener;
+import xyz.wagyourtail.jsmacros.core.service.ServiceManager;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
@@ -58,6 +59,11 @@ public abstract class BaseScriptContext<T> {
 
     public void clearSyncObject() {
         this.syncObjectPrivate = null;
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public boolean shouldKeepAlive() {
+        return this.hasMethodWrapperBeenInvoked || ServiceManager.hasKeepAlive(this);
     }
 
     /**

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/library/impl/FJsMacros.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/library/impl/FJsMacros.java
@@ -408,6 +408,7 @@ public class FJsMacros extends PerExecLibrary {
             }
         };
         Core.getInstance().eventRegistry.addListener(event, listener);
+        ctx.eventListeners.put(listener, event);
         return listener;
     }
 
@@ -496,6 +497,7 @@ public class FJsMacros extends PerExecLibrary {
 
         };
         Core.getInstance().eventRegistry.addListener(event, listener);
+        ctx.eventListeners.put(listener, event);
         return listener;
     }
 
@@ -740,6 +742,7 @@ public class FJsMacros extends PerExecLibrary {
             };
             // register the listener
             Core.getInstance().eventRegistry.addListener(event, listener);
+            ctx.eventListeners.put(listener, event);
 
             // run before, this is a thread-safety thing to prevent "interrupts" from going in between this and things like deferCurrentTask
             // it is thread safe because we already registered the listener so we won't miss any events

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/library/impl/FJsMacros.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/library/impl/FJsMacros.java
@@ -886,6 +886,7 @@ public class FJsMacros extends PerExecLibrary {
     public interface ScriptEventListener extends IEventListener {
         String getCreatorName();
 
+        @Nullable
         MethodWrapper<BaseEvent, EventContainer<?>, Object, ?> getWrapper();
 
     }

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/service/EventService.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/service/EventService.java
@@ -45,8 +45,7 @@ public class EventService extends BaseEvent {
      * The order of execution is run stopListener -> off events -> unregister stuff -> run postStopListener.<br>
      * <br>
      * If anything was set to unregister, the service won't stop by itself even if it reaches the end.
-     * @param offEvents whether the service manager should clear event listeners on stop.
-     *                  it's generally recommended to set to true, because callbacks cannot run after context closed.
+     * @param offEvents whether the service manager should clear event listeners that the callback doesn't belong to this context.
      * @param list the list of registrable, such as Draw2D, Draw3D and CommandBuilder.
      * @since 1.9.1
      */

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/service/EventService.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/service/EventService.java
@@ -7,6 +7,7 @@ import xyz.wagyourtail.jsmacros.core.MethodWrapper;
 import xyz.wagyourtail.jsmacros.core.classes.Registrable;
 import xyz.wagyourtail.jsmacros.core.event.BaseEvent;
 import xyz.wagyourtail.jsmacros.core.event.Event;
+import xyz.wagyourtail.jsmacros.core.language.BaseScriptContext;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,6 +33,12 @@ public class EventService extends BaseEvent {
     @Nullable
     public MethodWrapper<Object, Object, Object, ?> postStopListener;
 
+    boolean offEventsOnStop = false;
+    @Nullable
+    Registrable<?>[] registrableList = null;
+    @Nullable
+    BaseScriptContext<?> ctx = null;
+
     public EventService(String name) {
         this.serviceName = name;
     }
@@ -50,7 +57,12 @@ public class EventService extends BaseEvent {
      * @since 1.9.1
      */
     public void unregisterOnStop(boolean offEvents, Registrable<?> ...list) {
-        ServiceManager.setUnregisterSecret(this, offEvents, list);
+        offEventsOnStop = offEvents;
+        registrableList = list.length > 0 ? list : null;
+
+        if (ctx != null) {
+            ServiceManager.setAutoUnregisterKeepAlive(ctx, offEvents || registrableList != null);
+        }
     }
 
     @Override

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/service/EventService.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/service/EventService.java
@@ -44,7 +44,7 @@ public class EventService extends BaseEvent {
      * <br>
      * The order of execution is run stopListener -> off events -> unregister stuff -> run postStopListener.<br>
      * <br>
-     * Note that if the script stopped by itself (stopped without you stopping it in the gui), this won't take effect.
+     * If anything was set to unregister, the service won't stop by itself even if it reaches the end.
      * @param offEvents whether the service manager should clear event listeners on stop.
      *                  it's generally recommended to set to true, because callbacks cannot run after context closed.
      * @param list the list of registrable, such as Draw2D, Draw3D and CommandBuilder.

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/service/ServiceManager.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/service/ServiceManager.java
@@ -6,6 +6,7 @@ import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import xyz.wagyourtail.Pair;
 import xyz.wagyourtail.jsmacros.core.Core;
 import xyz.wagyourtail.jsmacros.core.config.CoreConfigV2;
+import xyz.wagyourtail.jsmacros.core.language.BaseScriptContext;
 import xyz.wagyourtail.jsmacros.core.language.EventContainer;
 
 import java.util.*;
@@ -143,13 +144,8 @@ public class ServiceManager {
             return ServiceStatus.UNKNOWN;
         }
         if (service.getU() != null && !service.getU().getCtx().isContextClosed()) {
-            try {
-                if (((EventService) service.getU().getCtx().getTriggeringEvent()).stopListener != null) {
-                    ((EventService) service.getU().getCtx().getTriggeringEvent()).stopListener.run();
-                }
-            } catch (Throwable e) {
-                runner.profile.logError(e);
-            }
+            BaseScriptContext<?> ctx = service.getU().getCtx();
+            ((EventService) ctx.getTriggeringEvent())._onStop(ctx, runner.profile::logError);
             service.getU().getCtx().closeContext();
             return ServiceStatus.RUNNING;
         }

--- a/src/core/java/xyz/wagyourtail/jsmacros/core/service/ServiceManager.java
+++ b/src/core/java/xyz/wagyourtail/jsmacros/core/service/ServiceManager.java
@@ -218,7 +218,7 @@ public class ServiceManager {
 
         if (secret.ctx != null) {
             synchronized (autoUnregisterKeepAlive) {
-                if (offEvents || list.length > 0) {
+                if (list.length > 0) {
                     autoUnregisterKeepAlive.add(secret.ctx.getSyncObject());
                 } else {
                     autoUnregisterKeepAlive.remove(secret.ctx.getSyncObject());

--- a/src/fabric/java/xyz/wagyourtail/jsmacros/fabric/client/api/classes/CommandBuilderFabric.java
+++ b/src/fabric/java/xyz/wagyourtail/jsmacros/fabric/client/api/classes/CommandBuilderFabric.java
@@ -92,7 +92,7 @@ public class CommandBuilderFabric extends CommandBuilder {
     }
 
     @Override
-    public void register() {
+    public CommandBuilder register() {
         or(1);
         CommandDispatcher<FabricClientCommandSource> dispatcher = ClientCommandManager.getActiveDispatcher();
         Function<CommandRegistryAccess, ArgumentBuilder<FabricClientCommandSource, ?>> head = pointer.pop().getU();
@@ -105,10 +105,11 @@ public class CommandBuilderFabric extends CommandBuilder {
             }
         }
         commands.put(name, head);
+        return this;
     }
 
     @Override
-    public void unregister() throws IllegalAccessException {
+    public CommandBuilder unregister() throws IllegalAccessException {
         CommandNodeAccessor.remove(ClientCommandManager.getActiveDispatcher().getRoot(), name);
         ClientPlayNetworkHandler p = MinecraftClient.getInstance().getNetworkHandler();
         if (p != null) {
@@ -116,6 +117,7 @@ public class CommandBuilderFabric extends CommandBuilder {
             CommandNodeAccessor.remove(cd.getRoot(), name);
         }
         commands.remove(name);
+        return this;
     }
 
     public static void registerEvent() {

--- a/src/forge/java/xyz/wagyourtail/jsmacros/forge/client/api/classes/CommandBuilderForge.java
+++ b/src/forge/java/xyz/wagyourtail/jsmacros/forge/client/api/classes/CommandBuilderForge.java
@@ -95,7 +95,7 @@ public class CommandBuilderForge extends CommandBuilder {
     }
 
     @Override
-    public void register() {
+    public CommandBuilder register() {
         or(1);
         CommandDispatcher<ServerCommandSource> dispatcher = ClientCommandHandler.getDispatcher();
         Function<CommandRegistryAccess, ArgumentBuilder<ServerCommandSource, ?>> head = pointer.pop().getU();
@@ -108,10 +108,11 @@ public class CommandBuilderForge extends CommandBuilder {
             }
         }
         commands.put(name, head);
+        return this;
     }
 
     @Override
-    public void unregister() throws IllegalAccessException {
+    public CommandBuilder unregister() throws IllegalAccessException {
         CommandNodeAccessor.remove(ClientCommandHandler.getDispatcher().getRoot(), name);
         ClientPlayNetworkHandler p = MinecraftClient.getInstance().getNetworkHandler();
         if (p != null) {
@@ -119,6 +120,7 @@ public class CommandBuilderForge extends CommandBuilder {
             CommandNodeAccessor.remove(cd.getRoot(), name);
         }
         commands.remove(name);
+        return this;
     }
 
     public static void onRegisterEvent(RegisterClientCommandsEvent event) {

--- a/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/inventory/CommandBuilder.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/inventory/CommandBuilder.java
@@ -17,6 +17,7 @@ import xyz.wagyourtail.jsmacros.client.api.helpers.world.BlockPosHelper;
 import xyz.wagyourtail.jsmacros.core.Core;
 import xyz.wagyourtail.jsmacros.core.EventLockWatchdog;
 import xyz.wagyourtail.jsmacros.core.MethodWrapper;
+import xyz.wagyourtail.jsmacros.core.classes.Registrable;
 import xyz.wagyourtail.jsmacros.core.config.CoreConfigV2;
 import xyz.wagyourtail.jsmacros.core.event.BaseEvent;
 import xyz.wagyourtail.jsmacros.core.event.IEventListener;
@@ -34,7 +35,7 @@ import java.util.stream.Collectors;
  * @since 1.4.2
  */
 @SuppressWarnings("unused")
-public abstract class CommandBuilder {
+public abstract class CommandBuilder implements Registrable<CommandBuilder> {
 
     protected abstract void argument(String name, Supplier<ArgumentType<?>> type);
 
@@ -434,12 +435,14 @@ public abstract class CommandBuilder {
 
     }
 
-    public abstract void register();
+    @Override
+    public abstract CommandBuilder register();
 
     /**
      * @since 1.6.5
      * removes this command
      */
-    public abstract void unregister() throws IllegalAccessException;
+    @Override
+    public abstract CommandBuilder unregister() throws IllegalAccessException;
 
 }

--- a/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/render/Draw2D.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/render/Draw2D.java
@@ -14,6 +14,7 @@ import xyz.wagyourtail.jsmacros.client.api.helpers.inventory.ItemStackHelper;
 import xyz.wagyourtail.jsmacros.client.api.library.impl.FHud;
 import xyz.wagyourtail.jsmacros.core.Core;
 import xyz.wagyourtail.jsmacros.core.MethodWrapper;
+import xyz.wagyourtail.jsmacros.core.classes.Registrable;
 
 import java.util.*;
 import java.util.function.IntSupplier;
@@ -25,7 +26,7 @@ import java.util.stream.Collectors;
  * @since 1.0.5
  */
 @SuppressWarnings("deprecation")
-public class Draw2D implements IDraw2D<Draw2D> {
+public class Draw2D implements IDraw2D<Draw2D>, Registrable<Draw2D> {
     protected final Set<RenderElement> elements = new LinkedHashSet<>();
     public IntSupplier widthSupplier;
     public IntSupplier heightSupplier;
@@ -638,6 +639,7 @@ public class Draw2D implements IDraw2D<Draw2D> {
      * @return self for chaining
      * @since 1.6.5
      */
+    @Override
     public Draw2D register() {
         this.init();
         FHud.overlays.add(this);
@@ -650,6 +652,7 @@ public class Draw2D implements IDraw2D<Draw2D> {
      * @return self for chaining
      * @since 1.6.5
      */
+    @Override
     public Draw2D unregister() {
         FHud.overlays.remove(this);
         return this;

--- a/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/render/Draw3D.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/api/classes/render/Draw3D.java
@@ -15,6 +15,7 @@ import xyz.wagyourtail.jsmacros.client.api.classes.render.components3d.*;
 import xyz.wagyourtail.jsmacros.client.api.helpers.world.BlockPosHelper;
 import xyz.wagyourtail.jsmacros.client.api.helpers.world.entity.EntityHelper;
 import xyz.wagyourtail.jsmacros.client.api.library.impl.FHud;
+import xyz.wagyourtail.jsmacros.core.classes.Registrable;
 
 import java.util.*;
 
@@ -25,7 +26,7 @@ import java.util.*;
  * @since 1.0.6
  */
 @SuppressWarnings("unused")
-public class Draw3D {
+public class Draw3D implements Registrable<Draw3D> {
     private final ArrayList<RenderElement3D> elements = new ArrayList<>();
 
     /**
@@ -676,6 +677,7 @@ public class Draw3D {
      * @return self for chaining
      * @since 1.6.5
      */
+    @Override
     public Draw3D register() {
         FHud.renders.add(this);
         return this;
@@ -685,6 +687,7 @@ public class Draw3D {
      * @return self for chaining
      * @since 1.6.5
      */
+    @Override
     public Draw3D unregister() {
         FHud.renders.remove(this);
         return this;


### PR DESCRIPTION
I find it unnecessary to do something like
```js
event.stopListener = JavaWrapper.methodToJava(() => {
  d2d.unregister()
  d3d.unregister()
  cmd.unregister()
  eventListener.off()
})
```
every time writing a service. so I made this pr to add a method that handles this stuff.
```js
event.unregisterOnStop(true, d2d, d3d, cmd)
```

see [EventService.java:L47-L60](https://github.com/aMelonRind/JsMacros/blob/auto-unregister/src/core/java/xyz/wagyourtail/jsmacros/core/service/EventService.java#L47-L60) for more information.