### PR TITLE
fix: make EventSignEdit's event.signText return the actual sign content

### DIFF
--- a/src/main/java/xyz/wagyourtail/jsmacros/client/access/ISignEditScreen.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/access/ISignEditScreen.java
@@ -3,5 +3,5 @@ package xyz.wagyourtail.jsmacros.client.access;
 public interface ISignEditScreen {
 
     void jsmacros_setLine(int line, String text);
-
+    void jsmacros_fixSelection();
 }

--- a/src/main/java/xyz/wagyourtail/jsmacros/client/api/event/impl/player/EventSignEdit.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/api/event/impl/player/EventSignEdit.java
@@ -15,12 +15,14 @@ import java.util.List;
 public class EventSignEdit extends BaseEvent {
     public final Pos3D pos;
     public boolean closeScreen = false;
+    public boolean front;
     @Nullable
     public List<String> signText;
 
     @SuppressWarnings("NullableProblems")
-    public EventSignEdit(List<String> signText, int x, int y, int z) {
+    public EventSignEdit(List<String> signText, int x, int y, int z, boolean front) {
         this.pos = new Pos3D(x, y, z);
+        this.front = front;
         this.signText = signText;
     }
 

--- a/src/main/java/xyz/wagyourtail/jsmacros/client/mixins/access/MixinSignEditScreen.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/mixins/access/MixinSignEditScreen.java
@@ -3,7 +3,9 @@ package xyz.wagyourtail.jsmacros.client.mixins.access;
 import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.block.entity.SignText;
 import net.minecraft.client.gui.screen.ingame.AbstractSignEditScreen;
+import net.minecraft.client.util.SelectionManager;
 import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -27,12 +29,25 @@ public abstract class MixinSignEditScreen implements ISignEditScreen {
     @Shadow
     private SignText text;
 
+    @Shadow
+    @Nullable
+    private SelectionManager selectionManager;
+
+    @Shadow
+    private int currentRow;
+
     @Override
     public void jsmacros_setLine(int line, String text) {
         this.messages[line] = text; // actual
         this.text = this.text.withMessage(line, Text.of(text)); // gui visual
         // this needs to be called on main thread when sodium is installed
 //        this.blockEntity.setText(this.text, this.front); // block visual
+    }
+
+    @Override
+    public void jsmacros_fixSelection() {
+        int pos = this.messages[this.currentRow].length() + 1;
+        if (this.selectionManager != null) this.selectionManager.moveCursorTo(pos, false);
     }
 
 }

--- a/src/main/java/xyz/wagyourtail/jsmacros/client/mixins/events/MixinClientPlayerEntity.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/mixins/events/MixinClientPlayerEntity.java
@@ -32,6 +32,7 @@ import xyz.wagyourtail.jsmacros.client.movement.MovementQueue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mixin(ClientPlayerEntity.class)
 abstract class MixinClientPlayerEntity extends AbstractClientPlayerEntity {
@@ -68,8 +69,11 @@ abstract class MixinClientPlayerEntity extends AbstractClientPlayerEntity {
 
     @Inject(at = @At("HEAD"), method = "openEditSignScreen", cancellable = true)
     public void onOpenEditSignScreen(SignBlockEntity sign, boolean front, CallbackInfo ci) {
-        List<String> lines = new ArrayList<>(Arrays.asList("", "", "", ""));
-        final EventSignEdit event = new EventSignEdit(lines, sign.getPos().getX(), sign.getPos().getY(), sign.getPos().getZ());
+        List<String> lines = Arrays.stream(sign.getText(front)
+                .getMessages(client.shouldFilterText()))
+                .map(Text::getString)
+                .collect(Collectors.toList());
+        final EventSignEdit event = new EventSignEdit(lines, sign.getPos().getX(), sign.getPos().getY(), sign.getPos().getZ(), front);
         event.trigger();
         lines = event.signText;
         if (lines == null) lines = Arrays.asList("", "", "", "");
@@ -99,6 +103,7 @@ abstract class MixinClientPlayerEntity extends AbstractClientPlayerEntity {
                 //noinspection DataFlowIssue
                 ((ISignEditScreen) signScreen).jsmacros_setLine(i, lines.get(i));
             }
+            ((ISignEditScreen) signScreen).jsmacros_fixSelection();
             ci.cancel();
         }
     }


### PR DESCRIPTION
Fixes #173

I'm using `front` to choose which side of the sign should be in `event.signText`.

`jsmacros_fixSelection()` sets the current text selection (moves the cursor) in order to prevent text length related crashes. Without this workaround if you set `event.signText[0]` (where the cursor is when you open the sign edit screen by default) to be shorter than its initial value, then try to backspace or move the cursor, you will crash your game with an IndexOutOfBoundsException due to selection not being updated correctly. Feel free to comment it out and test.

The only extra addition to EventSignEdit is `event.front`, it provides `front` for advanced scripts.

Tested on Fabric 1.21