### PR TITLE
fix: open the correct sign edit screen after editing the sign text

### DIFF
--- a/src/main/java/xyz/wagyourtail/jsmacros/client/mixins/events/MixinClientPlayerEntity.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/client/mixins/events/MixinClientPlayerEntity.java
@@ -1,9 +1,12 @@
 package xyz.wagyourtail.jsmacros.client.mixins.events;
 
 import com.mojang.authlib.GameProfile;
+import net.minecraft.block.entity.HangingSignBlockEntity;
 import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.block.entity.SignText;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ingame.AbstractSignEditScreen;
+import net.minecraft.client.gui.screen.ingame.HangingSignEditScreen;
 import net.minecraft.client.gui.screen.ingame.SignEditScreen;
 import net.minecraft.client.input.Input;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
@@ -93,7 +96,13 @@ abstract class MixinClientPlayerEntity extends AbstractClientPlayerEntity {
             }
         } //else
         if (cancel) {
-            final SignEditScreen signScreen = new SignEditScreen(sign, front, true);
+            // we're checking the type of block entity to choose the correct screen here.
+            AbstractSignEditScreen signScreen;
+            if (sign instanceof HangingSignBlockEntity hs) {
+                signScreen = new HangingSignEditScreen(hs, front, client.shouldFilterText());
+            } else {
+                signScreen = new SignEditScreen(sign, front, client.shouldFilterText());
+            }
             client.setScreen(signScreen);
             for (int i = 0; i < 4; ++i) {
                 //noinspection DataFlowIssue


### PR DESCRIPTION
When you use `e.signText` to edit a sign, JsMacros opens the wrong screen for hanging signs.

This PR solves the problem by checking if the sign block entity is a `HangingSignBlockEntity` or not.

Example script:

```js
// run as a service
JsMacros.on("SignEdit", true, JavaWrapper.methodToJava((e) => {
    e.signText[0] = "1234"
}))
```

Before (d31365b057bb1ba6443f9d768b40908b503f9dde):
![image](https://github.com/user-attachments/assets/aec97673-a894-4241-a009-853731ebcdfb)

After (this PR):
![image](https://github.com/user-attachments/assets/08ddd063-5ce7-4bad-a45b-be174dbd1530)

Tested on Fabric 1.21